### PR TITLE
Add types feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ nosetests.xml
 
 # Sphinx
 docs/_*
+
+# jython
+*$py.class
+
+.idea/

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ except ImportError:
 
 import pytest
 
-import docopt
+import type_docopt
 
 
 def pytest_collect_file(path, parent):
@@ -54,8 +54,8 @@ class DocoptTestItem(pytest.Item):
 
     def runtest(self):
         try:
-            result = docopt.docopt(self.doc, argv=self.argv)
-        except docopt.DocoptExit:
+            result = type_docopt.docopt(self.doc, argv=self.argv)
+        except type_docopt.DocoptExit:
             result = 'user-error'
 
         if self.expect != result:

--- a/docopt.py
+++ b/docopt.py
@@ -13,6 +13,13 @@ import re
 __all__ = ['docopt']
 __version__ = '0.6.2'
 
+TYPE_MAP = {
+    'int': int,
+    'float': float,
+    'complex': complex,
+    'str': str,
+}
+
 
 class DocoptLanguageError(Exception):
 
@@ -190,9 +197,8 @@ class Option(ChildPattern):
         self.short, self.long, self.argcount = short, long, argcount
 
         if type_value is not None:
-            type_dict = {'int': int, 'float': float, }
-            assert type_value in type_dict or type_value == 'str'
-            self.type_class = type_dict[type_value] if type_value in type_dict else str
+            assert type_value in TYPE_MAP or type_value == 'str'
+            self.type_class = TYPE_MAP[type_value]
         else:
             self.type_class = None
         if choices_value is not None:

--- a/docopt.py
+++ b/docopt.py
@@ -185,11 +185,26 @@ class Command(Argument):
 
 class Option(ChildPattern):
 
-    def __init__(self, short=None, long=None, argcount=0, value=False):
+    def __init__(self, short=None, long=None, argcount=0, value=False, type_value=None, choices_value=None):
         assert argcount in (0, 1)
-        self.short, self.long = short, long
-        self.argcount, self.value = argcount, value
+        self.short, self.long, self.argcount = short, long, argcount
+
+        if type_value is not None:
+            type_dict = {'int': int, 'float': float, }
+            assert type_value in type_dict or type_value == 'str'
+            self.type_class = type_dict[type_value] if type_value in type_dict else str
+        else:
+            self.type_class = None
+        if choices_value is not None:
+            self.choices = [choice.strip() for choice in choices_value.split(' ')]
+        else:
+            self.choices = None
+
+        value = self.update_value(value)
         self.value = None if value is False and argcount else value
+
+        self.type_value = type_value
+        self.choices_value = choices_value
 
     @classmethod
     def parse(class_, option_description):
@@ -204,15 +219,31 @@ class Option(ChildPattern):
             else:
                 argcount = 1
         if argcount:
-            matched = re.findall('\[default: (.*)\]', description, flags=re.I)
+            matched = re.findall('\[default: (.*?)\]', description, flags=re.I)
             value = matched[0] if matched else None
-        return class_(short, long, argcount, value)
+
+        type_matched = re.findall('\[type: (.*?)\]', description, flags=re.I)
+        type_value = type_matched[0] if type_matched else None
+
+        choices_matched = re.findall('\[choices: (.*?)\]', description, flags=re.I)
+        choices_value = choices_matched[0] if choices_matched else None
+
+        return class_(short, long, argcount, value, type_value, choices_value)
 
     def single_match(self, left):
         for n, p in enumerate(left):
             if self.name == p.name:
                 return n, p
         return None, None
+
+    def update_value(self, value):
+        if value is not None and not isinstance(value, bool) and self.choices is not None:
+            assert value in self.choices
+
+        if value is not None and not isinstance(value, bool) and self.type_class is not None:
+            value = self.type_class(value)
+
+        return value
 
     @property
     def name(self):
@@ -318,7 +349,7 @@ def parse_long(tokens, options):
             o = Option(None, long, argcount, value if argcount else True)
     else:
         o = Option(similar[0].short, similar[0].long,
-                   similar[0].argcount, similar[0].value)
+                   similar[0].argcount, similar[0].value, similar[0].type_value, similar[0].choices_value)
         if o.argcount == 0:
             if value is not None:
                 raise tokens.error('%s must not have an argument' % o.long)
@@ -328,7 +359,8 @@ def parse_long(tokens, options):
                     raise tokens.error('%s requires argument' % o.long)
                 value = tokens.move()
         if tokens.error is DocoptExit:
-            o.value = value if value is not None else True
+            o.value = o.update_value(value if value is not None else True)
+
     return [o]
 
 

--- a/docopt.py
+++ b/docopt.py
@@ -192,13 +192,18 @@ class Command(Argument):
 
 class Option(ChildPattern):
 
-    def __init__(self, short=None, long=None, argcount=0, value=False, type_value=None, choices_value=None):
+    def __init__(self, short=None, long=None, argcount=0, value=False, type_value=None, choices_value=None, types=None):
         assert argcount in (0, 1)
         self.short, self.long, self.argcount = short, long, argcount
 
         if type_value is not None:
-            assert type_value in TYPE_MAP or type_value == 'str'
-            self.type_class = TYPE_MAP[type_value]
+            if types is not None:
+                type_map = dict(**TYPE_MAP, **types)
+            else:
+                type_map = TYPE_MAP
+            assert type_value in type_map
+
+            self.type_class = type_map[type_value]
         else:
             self.type_class = None
         if choices_value is not None:
@@ -211,9 +216,10 @@ class Option(ChildPattern):
 
         self.type_value = type_value
         self.choices_value = choices_value
+        self.types = types
 
     @classmethod
-    def parse(class_, option_description):
+    def parse(class_, option_description, types=None):
         short, long, argcount, value = None, None, 0, False
         options, _, description = option_description.strip().partition('  ')
         options = options.replace(',', ' ').replace('=', ' ')
@@ -234,7 +240,7 @@ class Option(ChildPattern):
         choices_matched = re.findall('\[choices: (.*?)\]', description, flags=re.I)
         choices_value = choices_matched[0] if choices_matched else None
 
-        return class_(short, long, argcount, value, type_value, choices_value)
+        return class_(short, long, argcount, value, type_value, choices_value, types)
 
     def single_match(self, left):
         for n, p in enumerate(left):
@@ -355,7 +361,7 @@ def parse_long(tokens, options):
             o = Option(None, long, argcount, value if argcount else True)
     else:
         o = Option(similar[0].short, similar[0].long,
-                   similar[0].argcount, similar[0].value, similar[0].type_value, similar[0].choices_value)
+                   similar[0].argcount, similar[0].value, similar[0].type_value, similar[0].choices_value, similar[0].types)
         if o.argcount == 0:
             if value is not None:
                 raise tokens.error('%s must not have an argument' % o.long)
@@ -489,11 +495,11 @@ def parse_argv(tokens, options, options_first=False):
     return parsed
 
 
-def parse_defaults(doc):
+def parse_defaults(doc, types=None):
     # in python < 2.7 you can't pass flags=re.MULTILINE
     split = re.split('\n *(<\S+?>|-\S+?)', doc)[1:]
     split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])]
-    options = [Option.parse(s) for s in split if s.startswith('-')]
+    options = [Option.parse(s, types) for s in split if s.startswith('-')]
     #arguments = [Argument.parse(s) for s in split if s.startswith('<')]
     #return options, arguments
     return options
@@ -528,7 +534,7 @@ class Dict(dict):
         return '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(self.items()))
 
 
-def docopt(doc, argv=None, help=True, version=None, options_first=False):
+def docopt(doc, argv=None, help=True, version=None, options_first=False, types=None):
     """Parse `argv` based on command-line interface described in `doc`.
 
     `docopt` creates your command-line interface based on its
@@ -552,6 +558,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     options_first : bool (default: False)
         Set to True to require options preceed positional arguments,
         i.e. to forbid options and positional arguments intermix.
+    types : dict
 
     Returns
     -------
@@ -594,7 +601,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     if argv is None:
         argv = sys.argv[1:]
     DocoptExit.usage = printable_usage(doc)
-    options = parse_defaults(doc)
+    options = parse_defaults(doc, types)
     pattern = parse_pattern(formal_usage(DocoptExit.usage), options)
     # [default] syntax for argument is disabled
     #for a in pattern.flat(Argument):

--- a/examples/arguments_example.py
+++ b/examples/arguments_example.py
@@ -17,7 +17,7 @@ Options:
   --right  use right-hand side
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/calculator_example.py
+++ b/examples/calculator_example.py
@@ -14,7 +14,7 @@ Options:
   -h, --help
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/counted_example.py
+++ b/examples/counted_example.py
@@ -10,7 +10,7 @@ Try: counted_example.py -vvvvvvvvvv
      counted_example.py this.txt that.txt
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 print(docopt(__doc__))

--- a/examples/git/git.py
+++ b/examples/git/git.py
@@ -21,7 +21,7 @@ See 'git help <command>' for more information on a specific command.
 """
 from subprocess import call
 
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_add.py
+++ b/examples/git/git_add.py
@@ -16,7 +16,7 @@
     --ignore-missing     check if - even missing - files are ignored in dry run
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_branch.py
+++ b/examples/git/git_branch.py
@@ -26,7 +26,7 @@ Specific git-branch actions:
     --merged=<commit>     print only merged branches
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_checkout.py
+++ b/examples/git/git_checkout.py
@@ -16,7 +16,7 @@
     -p, --patch           select hunks interactively
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_clone.py
+++ b/examples/git/git_clone.py
@@ -23,7 +23,7 @@
     --depth <depth>       create a shallow clone of that depth
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_commit.py
+++ b/examples/git/git_commit.py
@@ -43,7 +43,7 @@ Commit contents options
                           [default: all]
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_push.py
+++ b/examples/git/git_push.py
@@ -20,7 +20,7 @@
     --progress            force progress reporting
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/git/git_remote.py
+++ b/examples/git/git_remote.py
@@ -15,7 +15,7 @@ usage: git remote [-v | --verbose]
     -v, --verbose         be verbose; must be placed before a subcommand
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/naval_fate.py
+++ b/examples/naval_fate.py
@@ -16,7 +16,7 @@ Options:
   --drifting    Drifting mine.
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/odd_even_example.py
+++ b/examples/odd_even_example.py
@@ -7,7 +7,7 @@ Options:
   -h, --help
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/options_example.py
+++ b/examples/options_example.py
@@ -31,7 +31,7 @@ Options:
   --doctest            run doctest on myself
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/options_shortcut_example.py
+++ b/examples/options_shortcut_example.py
@@ -12,7 +12,7 @@ Options:
   -q                       operate in quiet mode
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/quick_example.py
+++ b/examples/quick_example.py
@@ -4,7 +4,7 @@
   quick_example.py -h | --help | --version
 
 """
-from docopt import docopt
+from type_docopt import docopt
 
 
 if __name__ == '__main__':

--- a/examples/validation_example.py
+++ b/examples/validation_example.py
@@ -10,7 +10,7 @@ Options:
 """
 import os
 
-from docopt import docopt
+from type_docopt import docopt
 try:
     from schema import Schema, And, Or, Use, SchemaError
 except ImportError:

--- a/language_agnostic_testee.py
+++ b/language_agnostic_testee.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from docopt import docopt, DocoptExit
+from type_docopt import docopt, DocoptExit
 import sys, json
 
 doc = sys.stdin.read()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-from docopt import __version__
+from type_docopt import __version__
 
 
 setup(

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -587,47 +587,6 @@ def test_issue_85_any_option_multiple_subcommands():
                                             'good': False}
 
 
-usage = '''usage: this
-
-usage:hai
-usage: this that
-
-usage: foo
-       bar
-
-PROGRAM USAGE:
- foo
- bar
-usage:
-\ttoo
-\ttar
-Usage: eggs spam
-BAZZ
-usage: pit stop'''
-
-
-def test_parse_section():
-    assert parse_section('usage:', 'foo bar fizz buzz') == []
-    assert parse_section('usage:', 'usage: prog') == ['usage: prog']
-    assert parse_section('usage:',
-                         'usage: -x\n -y') == ['usage: -x\n -y']
-    assert parse_section('usage:', usage) == [
-            'usage: this',
-            'usage:hai',
-            'usage: this that',
-            'usage: foo\n       bar',
-            'PROGRAM USAGE:\n foo\n bar',
-            'usage:\n\ttoo\n\ttar',
-            'Usage: eggs spam',
-            'usage: pit stop',
-    ]
-
-
-def test_issue_126_defaults_not_parsed_correctly_when_tabs():
-    section = 'Options:\n\t--foo=<arg>  [default: bar]'
-    assert parse_defaults(section) == [Option(None, '--foo', 1, 'bar')]
-
-
 def test_types():
     doc = """Usage: prog [--data=<data>]\n
                  Options:\n\t-d --data=<data>    Input data [type: float]

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 
 import pytest
 
-from docopt import (docopt, DocoptExit, DocoptLanguageError,
+from type_docopt import (docopt, DocoptExit, DocoptLanguageError,
                     Option, Argument, Command, AnyOptions,
                     Required, Optional, Either, OneOrMore,
                     parse_argv, parse_pattern, #parse_defaults,

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -1,7 +1,5 @@
 from __future__ import with_statement
 
-import pytest
-
 from type_docopt import (docopt, DocoptExit, DocoptLanguageError,
                     Option, Argument, Command, AnyOptions,
                     Required, Optional, Either, OneOrMore,
@@ -588,50 +586,52 @@ def test_issue_85_any_option_multiple_subcommands():
 
 
 def test_types():
-    doc = """Usage: prog [--data=<data>]\n
-                 Options:\n\t-d --data=<data>    Input data [type: float]
-              """
+    doc = """Usage: prog [options]\n
+Options:\n  -d --data=<data>    Input data [type: float]"""
     a = docopt(doc, '--data=0.1')
     assert a == {'--data': 0.1}
     doc = """Usage: prog [--data=<data>]\n
-             Options:\n\t-d --data=<data>    Input data [default: 10] [type: int]
-          """
+Options:\n  -d --data=<data>    Input data [default: 10] [type: int]
+"""
     a = docopt(doc, '')
     assert a == {'--data': 10}
 
 
 def test_user_defined_types():
     doc = """Usage: prog [--data=<data>]\n
-                     Options:\n\t-d --data=<data>    Input data [type: Foo]
+                     Options:\n  -d --data=<data>    Input data [type: Foo]
                   """
     class Foo:
         def __init__(self, number):
             self.number = int(number)
             assert self.number < 10
 
+        def __eq__(self, other):
+            return self.number == other.number
+
     a = docopt(doc, '--data=1', types={'Foo': Foo})
     assert a == {'--data': Foo('1')}
 
-    with pytest.raises(AssertionError):
+    with raises(AssertionError):
         docopt(doc, '--data=20', types={'Foo': Foo})
 
 
 def test_choices():
     doc = """Usage: prog [--data=<data>]\n
-                 Options:\n\t-d --data=<data>    Input data [choices: A B C]
+                 Options:\n  -d --data=<data>    Input data [choices: A B C]
               """
     a = docopt(doc, '--data=A')
     assert a == {'--data': 'A'}
     doc = """Usage: prog [--data=<data>]\n
-                     Options:\n\t-d --data=<data>    Input data [choices: A B C] [default: C]
+                     Options:\n  -d --data=<data>    Input data [choices: A B C] [default: C]
                   """
     a = docopt(doc, '')
     assert a == {'--data': 'C'}
 
     doc = """Usage: prog [--data=<data>]\n
-             Options:\n\t-d --data=<data>    Input data [choices: A B C]
+             Options:\n  -d --data=<data>    Input data [choices: A B C]
           """
-    with pytest.raises(AssertionError):
+    with raises(AssertionError):
         docopt(doc, '--data=D')
 
 

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -633,3 +633,16 @@ def test_choices():
           """
     with pytest.raises(AssertionError):
         docopt(doc, '--data=D')
+
+
+# https://github.com/docopt/docopt/issues/259
+def test_blank_line_between_options():
+    doc = """Usage: prog [options]
+
+Options:
+  -d --data=<data>    Input data [default: 10] [type: int]
+
+  -i --input=<input>    Input [default: 0.1] [type: float]
+"""
+    a = docopt(doc, '')
+    assert a == {'--data': 10, '--input': 0.1}

--- a/type_docopt.py
+++ b/type_docopt.py
@@ -571,15 +571,15 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False, types=N
     -------
     >>> from type_docopt import docopt
     >>> doc = '''
-    Usage:
-        my_program tcp <host> <port> [--timeout=<seconds>]
-        my_program serial <port> [--baud=<n>] [--timeout=<seconds>]
-        my_program (-h | --help | --version)
-
-    Options:
-        -h, --help  Show this screen and exit.
-        --baud=<n>  Baudrate [default: 9600]
-    '''
+    ... Usage:
+    ...     my_program tcp <host> <port> [--timeout=<seconds>]
+    ...     my_program serial <port> [--baud=<n>] [--timeout=<seconds>]
+    ...     my_program (-h | --help | --version)
+    ...
+    ... Options:
+    ...     -h, --help  Show this screen and exit.
+    ...     --baud=<n>  Baudrate [default: 9600]
+    ... '''
     >>> argv = ['tcp', '127.0.0.1', '80', '--timeout', '30']
     >>> docopt(doc, argv)
     {'--baud': '9600',

--- a/type_docopt.py
+++ b/type_docopt.py
@@ -569,7 +569,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False, types=N
 
     Example
     -------
-    >>> from docopt import docopt
+    >>> from type_docopt import docopt
     >>> doc = '''
     Usage:
         my_program tcp <host> <port> [--timeout=<seconds>]


### PR DESCRIPTION
This PR implements the core functionality of this project, which is type validation feature.
You can now add [type: int] or [choices: A B C] to your docstring and the argument will be validated accordingly.

Public accessibility, documentation, etc. will be addressed in the later PRs.

(This PR adds feature onto docopt 0.6.2, not current master of docopt. This is because docopt's current master is experimental, and contains bugs.)